### PR TITLE
fix(blog): normalize post urls and tables

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -7,6 +7,7 @@ import pagefind from "astro-pagefind";
 // https://astro.build/config
 export default defineConfig({
   site: "https://andrewriefenstahl.com",
+  trailingSlash: "always",
   build: {
     format: "directory",
   },

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,2 @@
+/posts  /posts/  301
+/posts/:slug  /posts/:slug/  301

--- a/src/components/EnhancedPostCard.tsx
+++ b/src/components/EnhancedPostCard.tsx
@@ -98,7 +98,7 @@ const EnhancedPostCard = ({ post }: Props) => {
         </div>
 
         {/* Read More Button */}
-        <a href={`/posts/${post.slug}`} className="block">
+        <a href={`/posts/${post.slug}/`} className="block">
           <Button
             variant="outline"
             className="w-full transition-all duration-200 group-hover:border-border group-hover:bg-background"

--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -41,7 +41,7 @@ const { title, description, pubDate, image } = post.data;
       </CardContent>
       <CardFooter className="mt-auto flex items-center justify-between p-4">
         <Button asChild variant="outline">
-          <a href={"/posts/" + post.slug}>Read More</a>
+          <a href={`/posts/${post.slug}/`}>Read More</a>
         </Button>
       </CardFooter>
     </div>

--- a/src/components/PostNavigation.astro
+++ b/src/components/PostNavigation.astro
@@ -14,7 +14,7 @@ const { prevPost, nextPost } = Astro.props;
     <nav class="mt-16 flex items-stretch justify-between gap-4" aria-label="Post navigation">
       {prevPost ? (
         <a
-          href={`/posts/${prevPost.slug}`}
+          href={`/posts/${prevPost.slug}/`}
           class="group flex max-w-[45%] flex-col"
         >
           <span class="mb-2 flex items-center gap-1.5 text-xs text-muted-foreground/80 transition-colors group-hover:text-muted-foreground">
@@ -38,7 +38,7 @@ const { prevPost, nextPost } = Astro.props;
 
       {nextPost ? (
         <a
-          href={`/posts/${nextPost.slug}`}
+          href={`/posts/${nextPost.slug}/`}
           class="group ml-auto flex max-w-[45%] flex-col text-right"
         >
           <span class="mb-2 flex items-center justify-end gap-1.5 text-xs text-muted-foreground/80 transition-colors group-hover:text-muted-foreground">

--- a/src/components/RelatedPosts.astro
+++ b/src/components/RelatedPosts.astro
@@ -46,7 +46,7 @@ const formatDate = (date: Date) => {
       </h2>
       <div class="grid grid-cols-1 gap-6 sm:grid-cols-3">
         {relatedPosts.map((post) => (
-          <a href={`/posts/${post.slug}`} class="group block">
+          <a href={`/posts/${post.slug}/`} class="group block">
             {post.data.image && (
               <div class="mb-3 aspect-[16/10] overflow-hidden rounded-lg bg-secondary">
                 <Image

--- a/src/layouts/MarkdownPostLayout.astro
+++ b/src/layouts/MarkdownPostLayout.astro
@@ -21,8 +21,9 @@ interface Props {
 
 const { frontmatter, body, prevPost, nextPost, currentSlug, allPosts } = Astro.props;
 
-// Get the full current URL using Astro's built-in approach
-const fullUrl = Astro.url.toString();
+const siteUrl = Astro.site ?? new URL("https://andrewriefenstahl.com");
+const articlePath = `/posts/${currentSlug}/`;
+const fullUrl = new URL(articlePath, siteUrl).toString();
 const publishedIso = new Date(frontmatter.pubDate).toISOString();
 
 const metaTags = {

--- a/src/pages/posts/[...page].astro
+++ b/src/pages/posts/[...page].astro
@@ -36,7 +36,7 @@ const metaTags = {
       : `Writing & Musings - Page ${page.currentPage} - Andrew Riefenstahl`,
   description:
     "Personal reflections on technology, life, music, philosophy, and the human experience. A mix of technical insights, creative pursuits, and honest thoughts on navigating this world.",
-  url: `https://andrewriefenstahl.com/posts${page.currentPage === 1 ? "" : `/${page.currentPage}`}`,
+  url: `https://andrewriefenstahl.com/posts/${page.currentPage === 1 ? "" : `${page.currentPage}/`}`,
 };
 ---
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -155,11 +155,12 @@
 
   .article-prose table {
     width: 100%;
-    display: block;
-    overflow-x: auto;
-    border-collapse: collapse;
+    table-layout: fixed;
+    border-collapse: separate;
+    border-spacing: 0;
     border: 1px solid hsl(var(--border));
     border-radius: 1rem;
+    overflow: hidden;
     background: linear-gradient(
       180deg,
       hsl(var(--card) / 0.95) 0%,
@@ -180,9 +181,10 @@
   }
 
   .article-prose :is(th, td) {
-    min-width: 12rem;
+    min-width: 0;
     padding: 0.9rem 1rem;
     vertical-align: top;
+    overflow-wrap: anywhere;
   }
 
   .article-prose th {
@@ -208,5 +210,18 @@
   .article-prose code {
     background: hsl(var(--secondary) / 0.65);
     padding: 0.15rem 0.4rem;
+  }
+
+  @media (max-width: 767px) {
+    .article-prose table {
+      display: block;
+      overflow-x: auto;
+      table-layout: auto;
+    }
+
+    .article-prose :is(th, td) {
+      min-width: 12rem;
+      overflow-wrap: normal;
+    }
   }
 }


### PR DESCRIPTION
## Summary
- normalize blog post URLs to the trailing-slash form the site actually serves
- add Netlify redirects for old slashless `/posts/*` requests
- fix article table layout so desktop tables fill the prose width while mobile still scrolls

## Root cause
- post links and canonicals were emitting slashless URLs while the static build output lives under directory-style routes
- article tables were forced into a block overflow layout at all breakpoints, so the table shell stretched but the internal grid did not

## Validation
- `pnpm build`