### PR TITLE
feat(game): add secret dragon quest ending

### DIFF
--- a/src/components/games/DragonGame.tsx
+++ b/src/components/games/DragonGame.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef } from "react";
+import { useState, useCallback, useEffect, useMemo, useRef } from "react";
 import type { Direction, Position, ReactiveObject } from "@/lib/games/types";
 import {
   GAME_WIDTH,
@@ -14,6 +14,8 @@ import {
   ROAR_KEYS,
   CONTACT_DAMAGE,
   PLAYER_SIZE,
+  SECRET_GEM_TARGET,
+  TOTAL_ENEMIES,
 } from "@/lib/games/constants";
 import { checkAABBCollision } from "@/lib/games/collision";
 import { useGameLoop } from "@/hooks/games/useGameLoop";
@@ -47,10 +49,12 @@ function DragonGameInner({ onRestart }: { onRestart: () => void }) {
   const [dialogue, setDialogue] = useState<string | null>(null);
   const [dialogueTarget, setDialogueTarget] = useState<string | null>(null);
   const [showControls, setShowControls] = useState(true);
+  const [victoryOpen, setVictoryOpen] = useState(false);
 
   // Refs to break circular dependency between keyboard handler and player
   const playerPosRef = useRef<Position>(INITIAL_POSITION);
   const playerDirRef = useRef<Direction>("down");
+  const questUnlockedRef = useRef(false);
 
   // Responsive scaling
   const containerRef = useRef<HTMLDivElement>(null);
@@ -78,10 +82,53 @@ function DragonGameInner({ onRestart }: { onRestart: () => void }) {
     onEnemyDeath: (x, y) => collectibles.spawnLootBurst(x, y, 2),
   });
 
+  const chestOpened = objectStates.get("chest1") === "activated";
+  const rockShattered = objectStates.get("rock1") === "activated";
+  const enemiesRemaining = enemySystem.enemies.filter(
+    (enemy) => enemy.state !== "dead",
+  ).length;
+  const questSteps = useMemo(
+    () => [
+      {
+        id: "chest",
+        label: "Crack open the treasure chest",
+        complete: chestOpened,
+      },
+      {
+        id: "rock",
+        label: "Shatter the mysterious rock",
+        complete: rockShattered,
+      },
+      {
+        id: "enemies",
+        label: `Cull the cave creatures (${TOTAL_ENEMIES - enemiesRemaining}/${TOTAL_ENEMIES})`,
+        complete: enemiesRemaining === 0,
+      },
+      {
+        id: "gems",
+        label: `Gather dragon gems (${Math.min(collectibles.score, SECRET_GEM_TARGET)}/${SECRET_GEM_TARGET})`,
+        complete: collectibles.score >= SECRET_GEM_TARGET,
+      },
+    ],
+    [chestOpened, rockShattered, enemiesRemaining, collectibles.score],
+  );
+  const doorUnlocked = questSteps.every((step) => step.complete);
+
   const closeDialogue = useCallback(() => {
     setDialogue(null);
     setDialogueTarget(null);
   }, []);
+
+  useEffect(() => {
+    if (!doorUnlocked || questUnlockedRef.current) return;
+
+    questUnlockedRef.current = true;
+    activateObject("door1");
+    setDialogue(
+      "The ancient gate shudders awake.\nA portal blooms in the north wall.\nReturn to it and press E to escape.",
+    );
+    setDialogueTarget("Ancient Gate");
+  }, [doorUnlocked, activateObject]);
 
   // Touch input
   const touch = useTouch();
@@ -92,6 +139,26 @@ function DragonGameInner({ onRestart }: { onRestart: () => void }) {
   const handleInteract = useCallback(() => {
     const facing = getFacingObject(playerPosRef.current, playerDirRef.current);
     if (!facing) return;
+
+    if (facing.id === "door1") {
+      if (doorUnlocked) {
+        closeDialogue();
+        setVictoryOpen(true);
+        setDialogueTarget("Ancient Gate");
+        return;
+      }
+
+      const remainingSteps = questSteps
+        .filter((step) => !step.complete)
+        .map((step) => `• ${step.label}`)
+        .join("\n");
+
+      setDialogue(
+        `The gate rejects you.\n${remainingSteps || "• Something still feels unfinished."}`,
+      );
+      setDialogueTarget("Ancient Gate");
+      return;
+    }
 
     // Potion: heal + consume instead of dialogue
     if (
@@ -108,7 +175,15 @@ function DragonGameInner({ onRestart }: { onRestart: () => void }) {
 
     setDialogue(facing.dialogue);
     setDialogueTarget(facing.name);
-  }, [getFacingObject, objectStates, health, consumeObject]);
+  }, [
+    closeDialogue,
+    consumeObject,
+    doorUnlocked,
+    getFacingObject,
+    health,
+    objectStates,
+    questSteps,
+  ]);
 
   const handleAttack = useCallback(() => {
     if (dialogue) return;
@@ -121,25 +196,28 @@ function DragonGameInner({ onRestart }: { onRestart: () => void }) {
 
   const handleTouchAttack = useCallback(() => {
     dismissControls();
+    if (victoryOpen) return;
     if (dialogue) {
       closeDialogue();
       return;
     }
     handleAttack();
-  }, [dialogue, closeDialogue, handleAttack, dismissControls]);
+  }, [dialogue, closeDialogue, handleAttack, dismissControls, victoryOpen]);
 
   const handleTouchInteract = useCallback(() => {
     dismissControls();
+    if (victoryOpen) return;
     if (dialogue) {
       closeDialogue();
       return;
     }
     handleInteract();
-  }, [dialogue, closeDialogue, handleInteract, dismissControls]);
+  }, [dialogue, closeDialogue, handleInteract, dismissControls, victoryOpen]);
 
   const handleKeyDown = useCallback(
     (key: string) => {
       if (health.isDead) return;
+      if (victoryOpen) return;
 
       if (dialogue) {
         if (CLOSE_DIALOGUE_KEYS.has(key)) {
@@ -176,6 +254,7 @@ function DragonGameInner({ onRestart }: { onRestart: () => void }) {
       performAttack,
       handleInteract,
       health.isDead,
+      victoryOpen,
     ],
   );
 
@@ -218,30 +297,30 @@ function DragonGameInner({ onRestart }: { onRestart: () => void }) {
   // Touch handlers for powers
   const handleTouchFire = useCallback(() => {
     dismissControls();
-    if (dialogue || health.isDead) return;
+    if (dialogue || health.isDead || victoryOpen) return;
     powers.fireBreath();
-  }, [dialogue, powers, dismissControls, health.isDead]);
+  }, [dialogue, powers, dismissControls, health.isDead, victoryOpen]);
 
   const handleTouchDash = useCallback(() => {
     dismissControls();
-    if (dialogue || health.isDead) return;
+    if (dialogue || health.isDead || victoryOpen) return;
     powers.wingDash();
-  }, [dialogue, powers, dismissControls, health.isDead]);
+  }, [dialogue, powers, dismissControls, health.isDead, victoryOpen]);
 
   const handleTouchSpin = useCallback(() => {
     dismissControls();
-    if (dialogue || health.isDead) return;
+    if (dialogue || health.isDead || victoryOpen) return;
     powers.spinAttack();
-  }, [dialogue, powers, dismissControls, health.isDead]);
+  }, [dialogue, powers, dismissControls, health.isDead, victoryOpen]);
 
   const handleTouchRoar = useCallback(() => {
     dismissControls();
-    if (dialogue || health.isDead) return;
+    if (dialogue || health.isDead || victoryOpen) return;
     powers.dragonRoar();
-  }, [dialogue, powers, dismissControls, health.isDead]);
+  }, [dialogue, powers, dismissControls, health.isDead, victoryOpen]);
 
   useGameLoop({
-    paused: !!dialogue || health.isDead,
+    paused: !!dialogue || health.isDead || victoryOpen,
     onTick: (deltaTime) => {
       // 1. Player movement
       if (!powers.isDashing) {
@@ -308,7 +387,7 @@ function DragonGameInner({ onRestart }: { onRestart: () => void }) {
     },
   });
 
-  const facingObject: ReactiveObject | null = !dialogue
+  const facingObject: ReactiveObject | null = !dialogue && !victoryOpen
     ? getFacingObject(player.position, player.direction)
     : null;
 
@@ -348,6 +427,7 @@ function DragonGameInner({ onRestart }: { onRestart: () => void }) {
             maxHp={health.maxHp}
             score={collectibles.score}
             isDead={health.isDead}
+            isVictory={victoryOpen}
             onRestart={onRestart}
           >
             <GameUI
@@ -357,6 +437,8 @@ function DragonGameInner({ onRestart }: { onRestart: () => void }) {
               showControls={showControls}
               onCloseDialogue={closeDialogue}
               isTouchDevice={isTouchDevice}
+              questSteps={questSteps}
+              doorUnlocked={doorUnlocked}
             />
           </GameCanvas>
         </div>
@@ -383,11 +465,12 @@ function DragonGameInner({ onRestart }: { onRestart: () => void }) {
             Use the D-pad to move. Tap {"\u2694\uFE0F"} to attack,{" "}
             {"\uD83D\uDCAC"} to interact, {"\uD83D\uDD25"} fire breath,{" "}
             {"\uD83D\uDCA8"} dash, {"\uD83C\uDF00"} spin, {"\uD83D\uDCE2"} roar.
+            Wake the gate to finish the hidden quest.
           </p>
         ) : (
           <p>
             WASD to move, SPACE to attack, E to interact. Powers: Q fire, Shift
-            dash, R spin, F roar.
+            dash, R spin, F roar. Wake the gate to complete the hidden quest.
           </p>
         )}
       </div>

--- a/src/components/games/GameCanvas.tsx
+++ b/src/components/games/GameCanvas.tsx
@@ -45,6 +45,7 @@ interface GameCanvasProps {
   maxHp: number;
   score: number;
   isDead: boolean;
+  isVictory: boolean;
   onRestart: () => void;
   children?: React.ReactNode;
 }
@@ -68,6 +69,7 @@ export function GameCanvas({
   maxHp,
   score,
   isDead,
+  isVictory,
   onRestart,
   children,
 }: GameCanvasProps) {
@@ -346,8 +348,39 @@ export function GameCanvas({
       {/* Overlay UI (dialogue, prompts, controls) */}
       {children}
 
+      {/* Victory Screen */}
+      {isVictory && (
+        <div className="absolute inset-0 z-50 flex flex-col items-center justify-center bg-black/75 px-6 text-center">
+          <div className="mb-4 text-6xl">{"\uD83C\uDFC6"}</div>
+          <h2 className="mb-3 text-4xl font-bold text-emerald-300">
+            Secret Complete
+          </h2>
+          <p className="mb-2 max-w-md text-lg text-foreground">
+            You woke the ancient gate, cleared the grotto, and escaped with a
+            dragon's hoard.
+          </p>
+          <p className="mb-6 text-xl text-yellow-400">
+            {"\uD83D\uDC8E"} Final Score: {score}
+          </p>
+          <div className="flex flex-col gap-3 sm:flex-row">
+            <button
+              className="rounded-lg bg-foreground px-6 py-3 text-lg font-bold text-background transition hover:opacity-90"
+              onClick={onRestart}
+            >
+              Play Again
+            </button>
+            <a
+              className="rounded-lg border border-border bg-background/80 px-6 py-3 text-lg font-bold text-foreground transition hover:bg-background"
+              href="/"
+            >
+              Return Home
+            </a>
+          </div>
+        </div>
+      )}
+
       {/* Death Screen */}
-      {isDead && (
+      {isDead && !isVictory && (
         <div className="absolute inset-0 z-50 flex flex-col items-center justify-center bg-black/70">
           <h2 className="mb-4 text-4xl font-bold text-red-500">Game Over</h2>
           <p className="mb-6 text-xl text-yellow-400">

--- a/src/components/games/GameUI.tsx
+++ b/src/components/games/GameUI.tsx
@@ -1,5 +1,11 @@
 import type { ReactiveObject } from "@/lib/games/types";
 
+interface QuestStep {
+  id: string;
+  label: string;
+  complete: boolean;
+}
+
 interface GameUIProps {
   dialogue: string | null;
   dialogueTarget: string | null;
@@ -7,6 +13,8 @@ interface GameUIProps {
   showControls: boolean;
   onCloseDialogue: () => void;
   isTouchDevice?: boolean;
+  questSteps: QuestStep[];
+  doorUnlocked: boolean;
 }
 
 export function GameUI({
@@ -16,7 +24,18 @@ export function GameUI({
   showControls,
   onCloseDialogue,
   isTouchDevice,
+  questSteps,
+  doorUnlocked,
 }: GameUIProps) {
+  const promptText =
+    facingObject?.id === "door1" && doorUnlocked
+      ? isTouchDevice
+        ? "Tap 🌌"
+        : "Press E to escape"
+      : isTouchDevice
+        ? "Tap 💬"
+        : "Press E";
+
   return (
     <>
       {/* Interaction Prompt */}
@@ -24,11 +43,12 @@ export function GameUI({
         <div
           className="pointer-events-none absolute animate-bounce rounded-full bg-foreground px-3 py-1 text-sm font-bold text-background"
           style={{
-            left: facingObject.x + facingObject.width / 2 - 40,
+            left: facingObject.x + facingObject.width / 2,
             top: facingObject.y - 30,
+            transform: "translateX(-50%)",
           }}
         >
-          {isTouchDevice ? "Tap \uD83D\uDCAC" : "Press E"}
+          {promptText}
         </div>
       )}
 
@@ -41,7 +61,9 @@ export function GameUI({
           <h3 className="mb-2 text-sm font-bold text-background/80">
             {dialogueTarget}
           </h3>
-          <p className="text-lg text-background">{dialogue}</p>
+          <p className="whitespace-pre-line text-lg text-background">
+            {dialogue}
+          </p>
           <p className="mt-2 text-xs text-background/70">
             {isTouchDevice ? "Tap to close" : "Press SPACE or ESC to close"}
           </p>
@@ -61,6 +83,38 @@ export function GameUI({
           <p>F - Dragon Roar</p>
         </div>
       )}
+
+      {/* Secret quest tracker */}
+      <div
+        className={`absolute right-4 rounded-xl border px-4 py-3 shadow-lg backdrop-blur-sm ${
+          showControls && !isTouchDevice ? "top-[124px]" : "top-4"
+        } border-border bg-background/80 text-sm text-foreground`}
+        style={{ maxWidth: 250 }}
+      >
+        <p className="mb-1 text-[10px] font-bold uppercase tracking-[0.22em] text-yellow-300/80">
+          {doorUnlocked ? "Secret Found" : "Hidden Quest"}
+        </p>
+        <p className="mb-3 text-sm font-semibold text-foreground">
+          {doorUnlocked ? "Return to the north gate" : "Wake the ancient gate"}
+        </p>
+        <ul className="space-y-1.5 text-xs leading-relaxed text-muted-foreground">
+          {questSteps.map((step) => (
+            <li
+              key={step.id}
+              className={
+                step.complete
+                  ? "flex items-start gap-2 text-emerald-300"
+                  : "flex items-start gap-2"
+              }
+            >
+              <span className="mt-0.5 inline-block w-4 text-center font-bold">
+                {step.complete ? "✓" : "•"}
+              </span>
+              <span>{step.label}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
     </>
   );
 }

--- a/src/lib/games/constants.ts
+++ b/src/lib/games/constants.ts
@@ -131,6 +131,8 @@ export const ENEMY_SPAWNS: Array<{ type: EnemyType; x: number; y: number }> = [
   { type: "skeleton", x: 400, y: 150 },
 ];
 
+export const TOTAL_ENEMIES = ENEMY_SPAWNS.length;
+
 // --- Damage ---
 
 export const DAMAGE_VALUES: Record<AttackType, number> = {
@@ -150,6 +152,7 @@ export const CONTACT_DAMAGE = 1;
 export const GEM_PICKUP_RANGE = 35;
 export const GEM_LIFETIME = 10000;
 export const GEM_SIZE = 20;
+export const SECRET_GEM_TARGET = 8;
 
 // --- Hit Effects ---
 
@@ -194,13 +197,13 @@ export const REACTIVE_OBJECTS: ReactiveObject[] = [
     y: 20,
     emoji: "\u{1F6AA}",
     name: "Wooden Door",
-    dialogue: "The door is barred from the other side. You can't leave yet!",
+    dialogue: "The gate is sealed. Something in this grotto needs to be awakened first.",
     width: 80,
     height: 60,
     objectState: "default",
     reactsTo: [],
-    activatedEmoji: "\u{1F6AA}",
-    activatedDialogue: "",
+    activatedEmoji: "\uD83C\uDF00",
+    activatedDialogue: "The ancient gate hums to life. Press E to leave the grotto.",
     lootCount: 0,
   },
   {
@@ -226,7 +229,7 @@ export const REACTIVE_OBJECTS: ReactiveObject[] = [
     emoji: "\u{1F4DC}",
     name: "Ancient Scroll",
     dialogue:
-      "The scroll reads: 'Beware the dragon's wrath... wait, that's you!'",
+      "The scroll reads: 'Crack the chest. Burn the stone. Gather glitter. Silence the cave. Then the gate will wake.'",
     width: 35,
     height: 30,
     objectState: "default",

--- a/src/pages/games/dragon-quest.astro
+++ b/src/pages/games/dragon-quest.astro
@@ -4,7 +4,8 @@ import { DragonGame } from "../../components/games/DragonGame";
 
 const metaTags = {
   title: "Dragon Quest | Andrew Riefenstahl",
-  description: "A simple dragon adventure game - walk around, attack, and interact with objects!",
+  description:
+    "A hidden dragon-themed micro-quest tucked inside the site footer. Explore, fight, and uncover the ancient gate.",
   url: "https://andrewriefenstahl.com/games/dragon-quest",
 };
 ---
@@ -14,7 +15,9 @@ const metaTags = {
     <div class="max-w-4xl mx-auto">
       <header class="text-center mb-8">
         <h1 class="text-4xl font-bold text-foreground mb-2">Dragon Quest</h1>
-        <p class="text-muted-foreground">A proof-of-concept adventure game</p>
+        <p class="text-muted-foreground">
+          A hidden footer easter egg turned into a tiny quest
+        </p>
       </header>
       
       <DragonGame client:only="react" />
@@ -31,9 +34,10 @@ const metaTags = {
       >
         <h2>About This Game</h2>
         <p>
-          This is a simple proof-of-concept built with React and TypeScript, demonstrating 
-          basic game mechanics like character movement, collision detection, animations, 
-          and object interactions—all without any external game engines!
+          This started as a tiny proof-of-concept and evolved into a hidden
+          micro-adventure tucked into the site. It is intentionally small, but
+          now has an actual quest loop, a secret exit, and just enough friction
+          to feel like a real easter egg rather than a throwaway demo.
         </p>
         
         <h3>Features</h3>
@@ -41,6 +45,7 @@ const metaTags = {
           <li>Smooth 4-directional movement with WASD or arrow keys</li>
           <li>Animated attack system with visual feedback</li>
           <li>Interactive objects you can examine</li>
+          <li>A hidden quest tracker and unlockable ending</li>
           <li>Collision detection with walls and objects</li>
           <li>Dialogue system for storytelling</li>
         </ul>


### PR DESCRIPTION
## Summary
- turn the hidden Dragon Quest easter egg into a real micro-quest with a clear end state
- add quest progression, unlock conditions, and a proper victory overlay
- update the game page copy so the hidden feature feels intentional instead of incidental

## What changed
- door, chest, rock, enemy, and gem progress now feed a secret unlock condition
- add a quest tracker in the HUD and clearer clue text from the scroll
- unlock the final gate and show a completion overlay when the quest is finished

## Validation
- `pnpm build`