### PR TITLE
[codex] Refresh portfolio UI surfaces

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1165,8 +1165,8 @@ packages:
     resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
     engines: {node: '>= 6'}
 
-  caniuse-lite@1.0.30001764:
-    resolution: {integrity: sha512-9JGuzl2M+vPL+pz70gtMF9sHdMFbY9FJaQBi186cHKH3pSzDvzoUJUPV6fqiKIMyXbud9ZLg4F3Yza1vJ1+93g==}
+  caniuse-lite@1.0.30001793:
+    resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -3601,7 +3601,7 @@ snapshots:
   autoprefixer@10.4.21(postcss@8.5.6):
     dependencies:
       browserslist: 4.25.0
-      caniuse-lite: 1.0.30001764
+      caniuse-lite: 1.0.30001793
       fraction.js: 4.3.7
       normalize-range: 0.1.2
       picocolors: 1.1.1
@@ -3628,14 +3628,14 @@ snapshots:
 
   browserslist@4.25.0:
     dependencies:
-      caniuse-lite: 1.0.30001764
+      caniuse-lite: 1.0.30001793
       electron-to-chromium: 1.5.170
       node-releases: 2.0.19
       update-browserslist-db: 1.1.3(browserslist@4.25.0)
 
   camelcase-css@2.0.1: {}
 
-  caniuse-lite@1.0.30001764: {}
+  caniuse-lite@1.0.30001793: {}
 
   ccount@2.0.1: {}
 

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -16,6 +16,6 @@
   "theme_color": "#e7e5e4",
   "background_color": "#ffffff",
   "display": "standalone",
-  "start_url": "https://andrewriefenstahl.com",
+  "start_url": "/",
   "description": "Andrew Riefenstahl is a full-stack developer specializing in AI applications, secure web development, and MCP server architecture. Personal portfolio showcasing technical projects and philosophical writings."
 }

--- a/public/trees-bg.svg
+++ b/public/trees-bg.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="240" height="240" viewBox="0 0 240 240">
   <!-- Single deciduous tree centered in the tile -->
-  <g opacity="0.055" transform="translate(120,120) scale(0.9)">
+  <g opacity="0.16" transform="translate(120,120) scale(0.9)">
     <!-- Trunk -->
     <path d="M-4,20 L-5,55 L5,55 L4,20 Z" fill="hsl(30,18%,22%)"/>
     <!-- Main branches -->

--- a/src/components/ConnectSection.tsx
+++ b/src/components/ConnectSection.tsx
@@ -18,7 +18,7 @@ const ConnectSection = () => {
       url: "https://www.linkedin.com/in/andrewriefenstahl/",
       icon: Linkedin,
       description: "Professional network & insights",
-      color: "group-hover:text-[#0077b5]",
+      color: "group-hover:text-foreground",
     },
     {
       name: "GitHub",
@@ -32,7 +32,7 @@ const ConnectSection = () => {
       url: "https://twitter.com/riefer02",
       icon: Twitter,
       description: "Tech thoughts & discussions",
-      color: "group-hover:text-[#1DA1F2]",
+      color: "group-hover:text-foreground",
     },
     {
       name: "Email",

--- a/src/components/ConnectSection.tsx
+++ b/src/components/ConnectSection.tsx
@@ -25,7 +25,7 @@ const ConnectSection = () => {
       url: "https://github.com/riefer02",
       icon: Github,
       description: "Open source projects & code",
-      color: "group-hover:text-[#333]",
+      color: "group-hover:text-foreground",
     },
     {
       name: "Twitter",
@@ -44,14 +44,24 @@ const ConnectSection = () => {
   ];
 
   return (
-    <section id="connect" className="relative bg-background py-16 md:py-32">
+    <section
+      id="connect"
+      className="grounded-section relative bg-background py-16 md:py-32"
+    >
+      <div
+        className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-border to-transparent"
+        aria-hidden="true"
+      />
       <div className="container mx-auto max-w-5xl px-4">
         {/* Section Header */}
         <div className="mb-16 text-center">
-           <Badge variant="outline" className="mb-4 border-border bg-card/50 px-3 py-1 text-muted-foreground">
-             Contact
+          <Badge
+            variant="outline"
+            className="grounded-kicker mb-4 px-3 py-1 text-muted-foreground"
+          >
+            Contact
           </Badge>
-          <h2 className="mb-6 text-3xl font-bold tracking-tight text-foreground md:text-5xl">
+          <h2 className="grounded-section-heading mb-6 text-3xl font-bold tracking-tight text-foreground md:text-5xl">
             Let's Start a Conversation
           </h2>
           <p className="mx-auto max-w-2xl text-lg leading-relaxed text-muted-foreground">
@@ -73,10 +83,10 @@ const ConnectSection = () => {
                 rel={link.name === "Email" ? "" : "noopener noreferrer"}
                 className="group block h-full"
               >
-                <Card className="h-full border-border bg-card/80 transition-all duration-300 hover:-translate-y-1 hover:shadow-lg hover:shadow-primary/15">
+                <Card className="grounded-panel h-full rounded-lg transition-all duration-300 hover:-translate-y-1">
                   <CardContent className="flex items-center gap-6 p-8">
                     <div
-                      className={`flex h-16 w-16 shrink-0 items-center justify-center rounded-2xl bg-secondary text-muted-foreground transition-all duration-300 group-hover:scale-110 group-hover:bg-card group-hover:shadow-md ${link.color}`}
+                      className={`grounded-icon flex h-16 w-16 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition-all duration-300 group-hover:-translate-y-1 ${link.color}`}
                     >
                       <IconComponent className="h-8 w-8" aria-hidden="true" />
                     </div>
@@ -89,8 +99,11 @@ const ConnectSection = () => {
                       </p>
                     </div>
                     <div className="hidden sm:block">
-                      <div className="flex h-10 w-10 items-center justify-center rounded-full border border-border/70 bg-transparent text-muted-foreground/70 transition-all duration-300 group-hover:border-border group-hover:text-foreground">
-                        <ArrowRight className="h-5 w-5 -translate-x-1 transition-transform duration-300 group-hover:translate-x-0" aria-hidden="true" />
+                      <div className="flex h-10 w-10 items-center justify-center rounded-full border border-border/70 bg-transparent text-muted-foreground/70 shadow-[inset_0_1px_0_hsl(var(--foreground)/0.05)] transition-all duration-300 group-hover:border-[hsl(var(--glint)/0.42)] group-hover:text-foreground">
+                        <ArrowRight
+                          className="h-5 w-5 -translate-x-1 transition-transform duration-300 group-hover:translate-x-0"
+                          aria-hidden="true"
+                        />
                       </div>
                     </div>
                   </CardContent>
@@ -101,12 +114,12 @@ const ConnectSection = () => {
         </div>
 
         {/* CTA Section */}
-        <div className="relative overflow-hidden rounded-3xl border border-border/70 bg-gradient-to-br from-secondary via-card to-background px-6 py-16 text-center shadow-2xl md:px-12">
+        <div className="grounded-panel relative rounded-lg px-6 py-16 text-center md:px-12">
           <div className="relative z-10">
-            <div className="mx-auto mb-8 flex h-16 w-16 items-center justify-center rounded-2xl border border-border/60 bg-background/55 text-foreground">
+            <div className="grounded-icon mx-auto mb-8 flex h-16 w-16 items-center justify-center rounded-lg text-foreground">
               <MessageCircle className="h-8 w-8" aria-hidden="true" />
             </div>
-            
+
             <h3 className="mb-4 text-3xl font-bold text-foreground">
               Ready to collaborate?
             </h3>
@@ -114,11 +127,11 @@ const ConnectSection = () => {
               I'm available for interesting projects, consulting work, or just
               good conversations. Let's see what we can create together.
             </p>
-            
+
             <div className="flex flex-col items-center justify-center gap-4 sm:flex-row">
               <Button
                 asChild
-                className="h-12 rounded-full bg-primary px-8 text-base font-bold text-primary-foreground shadow-lg shadow-primary/30 transition-all hover:scale-105 hover:bg-primary/90"
+                className="grounded-button-primary h-12 rounded-full px-8 text-base font-bold text-primary-foreground transition-all hover:-translate-y-0.5"
                 size="lg"
               >
                 <a href="mailto:andrew.riefenstahl@gmail.com">
@@ -129,7 +142,7 @@ const ConnectSection = () => {
               <Button
                 asChild
                 variant="outline"
-                className="h-12 rounded-full border-border bg-transparent px-8 text-base text-foreground hover:bg-secondary hover:text-foreground"
+                className="grounded-button-outline h-12 rounded-full px-8 text-base text-foreground hover:-translate-y-0.5 hover:text-foreground"
                 size="lg"
               >
                 <a href="/posts/">Read My Writing</a>

--- a/src/components/ConnectSection.tsx
+++ b/src/components/ConnectSection.tsx
@@ -46,7 +46,7 @@ const ConnectSection = () => {
   return (
     <section
       id="connect"
-      className="grounded-section relative bg-background py-16 md:py-32"
+      className="grounded-section relative py-16 md:py-32"
     >
       <div
         className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-border to-transparent"

--- a/src/components/DesktopNav.tsx
+++ b/src/components/DesktopNav.tsx
@@ -14,7 +14,7 @@ const DesktopNav = () => {
           <a
             key={item.href}
             href={item.href}
-            className="flex items-center gap-2 rounded-full px-4 py-2 text-sm font-medium text-primary-foreground transition-all duration-200 hover:bg-primary-foreground/10 hover:text-primary-foreground"
+            className="text-primary-foreground/86 hover:border-primary-foreground/12 hover:bg-primary-foreground/8 flex items-center gap-2 rounded-full border border-transparent px-4 py-2 text-sm font-medium transition-all duration-200 hover:text-white hover:shadow-[inset_0_1px_0_hsl(var(--foreground)/0.08)]"
           >
             <IconComponent className="h-4 w-4" aria-hidden="true" />
             <span>{item.label}</span>

--- a/src/components/EnhancedKeyProjects.tsx
+++ b/src/components/EnhancedKeyProjects.tsx
@@ -47,7 +47,7 @@ const EnhancedKeyProjects = ({ keyProjects }: Props) => {
   return (
     <section
       id="projects"
-      className="grounded-section relative bg-background py-16 md:py-32"
+      className="grounded-section relative py-16 md:py-32"
     >
       <div
         className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-border to-transparent"

--- a/src/components/EnhancedKeyProjects.tsx
+++ b/src/components/EnhancedKeyProjects.tsx
@@ -45,16 +45,25 @@ const getProjectIcon = (projectName: string) => {
 
 const EnhancedKeyProjects = ({ keyProjects }: Props) => {
   return (
-    <section id="projects" className="relative py-16 md:py-32 bg-background">
-
+    <section
+      id="projects"
+      className="grounded-section relative bg-background py-16 md:py-32"
+    >
+      <div
+        className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-border to-transparent"
+        aria-hidden="true"
+      />
 
       <div className="container relative z-10 mx-auto px-4">
         {/* Section Header */}
         <div className="mb-16 text-center">
-          <Badge variant="outline" className="mb-4 border-border bg-card/50 px-3 py-1 text-muted-foreground">
-             Portfolio
+          <Badge
+            variant="outline"
+            className="grounded-kicker mb-4 px-3 py-1 text-muted-foreground"
+          >
+            Portfolio
           </Badge>
-          <h2 className="mb-6 text-3xl font-bold tracking-tight text-foreground md:text-5xl">
+          <h2 className="grounded-section-heading mb-6 text-3xl font-bold tracking-tight text-foreground md:text-5xl">
             Selected Work
           </h2>
           <p className="mx-auto max-w-2xl text-lg leading-relaxed text-muted-foreground">
@@ -71,22 +80,28 @@ const EnhancedKeyProjects = ({ keyProjects }: Props) => {
             return (
               <Card
                 key={project.name}
-                className="group relative flex h-full flex-col overflow-hidden border-border bg-card transition-all duration-500 hover:-translate-y-2 hover:shadow-2xl hover:shadow-primary/20"
+                className="grounded-panel group flex h-full flex-col rounded-lg transition-all duration-300 hover:-translate-y-1"
               >
                 <CardHeader className="pb-4">
                   <div className="mb-6 flex items-start justify-between">
-                    <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-secondary text-foreground transition-colors duration-300 group-hover:bg-foreground group-hover:text-background" aria-hidden="true">
+                    <div
+                      className="grounded-icon flex h-12 w-12 items-center justify-center rounded-lg text-foreground transition-colors duration-300 group-hover:bg-foreground group-hover:text-background"
+                      aria-hidden="true"
+                    >
                       <IconComponent className="h-6 w-6" />
                     </div>
                     <a
                       href={project.url}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="group/link flex items-center gap-1 rounded-full border border-border bg-card px-3 py-1.5 text-xs font-medium text-muted-foreground transition-all hover:border-primary hover:text-foreground"
+                      className="group/link relative flex items-center gap-1 rounded-full border border-border/70 bg-background/60 px-3 py-1.5 text-xs font-medium text-muted-foreground shadow-[inset_0_1px_0_hsl(var(--foreground)/0.06)] transition-all hover:border-[hsl(var(--glint)/0.44)] hover:text-foreground"
                       aria-label={`Visit ${project.name}`}
                     >
                       Visit
-                      <ArrowUpRight className="h-3 w-3 transition-transform group-hover/link:-translate-y-0.5 group-hover/link:translate-x-0.5" aria-hidden="true" />
+                      <ArrowUpRight
+                        className="h-3 w-3 transition-transform group-hover/link:-translate-y-0.5 group-hover/link:translate-x-0.5"
+                        aria-hidden="true"
+                      />
                     </a>
                   </div>
 
@@ -110,7 +125,7 @@ const EnhancedKeyProjects = ({ keyProjects }: Props) => {
                         <Badge
                           key={tech}
                           variant="secondary"
-                          className="bg-secondary text-xs font-normal text-muted-foreground transition-colors group-hover:bg-accent group-hover:text-foreground"
+                          className="grounded-chip text-xs font-normal text-muted-foreground transition-colors group-hover:border-[hsl(var(--glint)/0.36)] group-hover:text-foreground"
                         >
                           {tech}
                         </Badge>
@@ -130,7 +145,7 @@ const EnhancedKeyProjects = ({ keyProjects }: Props) => {
           </p>
           <Button
             asChild
-            className="h-12 rounded-full px-8 text-base font-semibold shadow-lg transition-all hover:scale-105 hover:shadow-xl"
+            className="grounded-button-primary h-12 rounded-full px-8 text-base font-semibold transition-all hover:-translate-y-0.5"
             size="lg"
           >
             <a href="#connect">Let's Connect</a>

--- a/src/components/ExpertiseSection.tsx
+++ b/src/components/ExpertiseSection.tsx
@@ -90,19 +90,31 @@ const ExpertiseSection = () => {
   ];
 
   return (
-    <section id="expertise" className="relative bg-background py-16 md:py-32">
+    <section
+      id="expertise"
+      className="grounded-section relative bg-background py-16 md:py-32"
+    >
+      <div
+        className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-border to-transparent"
+        aria-hidden="true"
+      />
 
       <div className="container mx-auto px-4">
         {/* Section Header */}
         <div className="mb-16 text-center">
-          <Badge variant="outline" className="mb-4 border-border bg-card/50 px-3 py-1 text-muted-foreground">
+          <Badge
+            variant="outline"
+            className="grounded-kicker mb-4 px-3 py-1 text-muted-foreground"
+          >
             Core Competencies
           </Badge>
-          <h2 className="mb-6 text-3xl font-bold tracking-tight text-foreground md:text-5xl">
+          <h2 className="grounded-section-heading mb-6 text-3xl font-bold tracking-tight text-foreground md:text-5xl">
             Technical & Leadership DNA
           </h2>
           <p className="mx-auto max-w-2xl text-lg leading-relaxed text-muted-foreground">
-            I bring a holistic approach to software engineering—combining deep technical expertise with a focus on sustainable architecture and human-centric leadership.
+            I bring a holistic approach to software engineering—combining deep
+            technical expertise with a focus on sustainable architecture and
+            human-centric leadership.
           </p>
         </div>
 
@@ -113,12 +125,10 @@ const ExpertiseSection = () => {
             return (
               <Card
                 key={index}
-                className="group relative h-full overflow-hidden border-border bg-card/80 p-2 transition-all duration-500 hover:-translate-y-1 hover:shadow-2xl hover:shadow-primary/15"
+                className="grounded-panel group h-full rounded-lg p-2 transition-all duration-300 hover:-translate-y-1"
               >
-                <div className="absolute inset-0 bg-gradient-to-br from-background/50 via-transparent to-transparent opacity-0 transition-opacity duration-500 group-hover:opacity-100" />
-                
                 <CardHeader className="relative pb-4">
-                  <div className="mb-6 inline-flex h-14 w-14 items-center justify-center rounded-2xl bg-secondary text-foreground transition-colors duration-300 group-hover:bg-foreground group-hover:text-background">
+                  <div className="grounded-icon mb-6 inline-flex h-14 w-14 items-center justify-center rounded-lg text-foreground transition-colors duration-300 group-hover:bg-foreground group-hover:text-background">
                     <IconComponent className="h-7 w-7" aria-hidden="true" />
                   </div>
                   <CardTitle className="text-2xl font-bold text-foreground">
@@ -134,7 +144,7 @@ const ExpertiseSection = () => {
                       <Badge
                         key={skillIndex}
                         variant="secondary"
-                        className="border border-border/70 bg-background px-3 py-1 text-sm font-normal text-muted-foreground transition-colors hover:border-border hover:bg-card hover:text-foreground"
+                        className="grounded-chip px-3 py-1 text-sm font-normal text-muted-foreground transition-colors hover:border-[hsl(var(--glint)/0.38)] hover:text-foreground"
                       >
                         {skill}
                       </Badge>
@@ -147,7 +157,7 @@ const ExpertiseSection = () => {
         </div>
 
         {/* Specializations Grid - Updated to match style */}
-        <div className="rounded-3xl border border-border bg-card/50 p-8 md:p-12">
+        <div className="grounded-panel rounded-lg p-8 md:p-12">
           <h3 className="mb-10 text-center text-xl font-semibold tracking-tight text-foreground">
             Specialized Capabilities
           </h3>
@@ -155,14 +165,22 @@ const ExpertiseSection = () => {
             {specializations.map((spec, index) => {
               const IconComponent = spec.icon;
               return (
-                <div key={index} className="group flex flex-col items-center text-center">
-                  <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-2xl border border-border/70 bg-card shadow-sm transition-all duration-300 group-hover:scale-110 group-hover:border-border group-hover:shadow-md">
-                    <IconComponent className="h-7 w-7 text-muted-foreground transition-colors group-hover:text-foreground" aria-hidden="true" />
+                <div
+                  key={index}
+                  className="group relative flex flex-col items-center text-center"
+                >
+                  <div className="grounded-icon mb-4 flex h-16 w-16 items-center justify-center rounded-lg transition-all duration-300 group-hover:-translate-y-1 group-hover:border-[hsl(var(--glint)/0.44)]">
+                    <IconComponent
+                      className="h-7 w-7 text-muted-foreground transition-colors group-hover:text-foreground"
+                      aria-hidden="true"
+                    />
                   </div>
                   <h4 className="mb-1.5 text-sm font-bold text-foreground">
                     {spec.label}
                   </h4>
-                  <p className="text-xs font-medium text-muted-foreground">{spec.desc}</p>
+                  <p className="text-xs font-medium text-muted-foreground">
+                    {spec.desc}
+                  </p>
                 </div>
               );
             })}

--- a/src/components/ExpertiseSection.tsx
+++ b/src/components/ExpertiseSection.tsx
@@ -92,7 +92,7 @@ const ExpertiseSection = () => {
   return (
     <section
       id="expertise"
-      className="grounded-section relative bg-background py-16 md:py-32"
+      className="grounded-section relative py-16 md:py-32"
     >
       <div
         className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-border to-transparent"

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -7,8 +7,7 @@ import profileImage from "../assets/Andrew-Riefenstahl.jpg";
 ---
 
 <header
-  class="fixed top-0 z-50 w-full border-b border-border/20 bg-gradient-to-r from-primary to-primary shadow-lg transition-all duration-300"
-  style="will-change: transform; transform: translateZ(0); backface-visibility: hidden;"
+  class="fixed top-0 z-50 w-full border-b border-foreground/10 bg-[linear-gradient(180deg,hsl(var(--surface-3)/0.98),hsl(var(--surface-2)/0.94))] shadow-[0_12px_40px_-28px_hsl(var(--depth-shadow)/0.9),inset_0_-1px_0_hsl(var(--foreground)/0.08)] transition-colors duration-300"
 >
   <div
     class="mx-auto flex w-full max-w-7xl items-center justify-between px-6 py-4"
@@ -23,20 +22,20 @@ import profileImage from "../assets/Andrew-Riefenstahl.jpg";
             width={80}
             height={80}
             loading="eager"
-            class="h-10 w-10 rounded-full ring-2 ring-ring/30 transition-all duration-200 group-hover:ring-ring/50"
+            class="h-10 w-10 rounded-full ring-2 ring-foreground/15 transition-all duration-200 group-hover:ring-[hsl(var(--glint)/0.55)]"
           />
           <div
-            class="absolute inset-0 rounded-full bg-gradient-to-tr from-primary/10 to-transparent"
+            class="absolute inset-0 rounded-full bg-gradient-to-tr from-background/15 to-transparent"
           >
           </div>
         </div>
         <div class="hidden sm:block">
           <span
-            class="text-xl font-bold text-primary-foreground transition-colors duration-200 group-hover:text-primary-foreground"
+            class="text-xl font-bold text-primary-foreground transition-colors duration-200 group-hover:text-white"
           >
             Andrew Riefenstahl
           </span>
-          <p class="-mt-1 text-sm font-medium text-primary-foreground/80">
+          <p class="-mt-1 text-sm font-medium text-primary-foreground/78">
             Developer & Thought Leader
           </p>
         </div>

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -4,7 +4,7 @@ import { Badge } from "@/components/ui/badge";
 
 const HeroSection = () => {
   return (
-    <section className="grounded-section relative w-full overflow-hidden bg-background py-16 md:py-32">
+    <section className="grounded-section relative w-full overflow-hidden py-16 md:py-32">
       <div
         className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-[hsl(var(--glint)/0.5)] to-transparent"
         aria-hidden="true"

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -18,8 +18,8 @@ const HeroSection = () => {
               className="grounded-kicker px-4 py-1.5 text-sm font-medium text-muted-foreground"
             >
               <span className="mr-2 flex h-2 w-2">
-                <span className="absolute inline-flex h-2 w-2 animate-ping rounded-full bg-emerald-400 opacity-75"></span>
-                <span className="relative inline-flex h-2 w-2 rounded-full bg-emerald-500"></span>
+                <span className="absolute inline-flex h-2 w-2 animate-ping rounded-full bg-[hsl(var(--hero-gradient-via))] opacity-75"></span>
+                <span className="relative inline-flex h-2 w-2 rounded-full bg-[hsl(var(--hero-gradient-via))]"></span>
               </span>
               System Online & Ready
             </Badge>

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -4,14 +4,22 @@ import { Badge } from "@/components/ui/badge";
 
 const HeroSection = () => {
   return (
-    <section className="relative w-full overflow-hidden bg-background py-16 md:py-32">
+    <section className="grounded-section relative w-full overflow-hidden bg-background py-16 md:py-32">
+      <div
+        className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-[hsl(var(--glint)/0.5)] to-transparent"
+        aria-hidden="true"
+      />
+      <div
+        className="pointer-events-none absolute left-1/2 top-10 h-72 w-[min(46rem,80vw)] -translate-x-1/2 rounded-full border border-[hsl(var(--glint)/0.08)] bg-[radial-gradient(circle,hsl(var(--glint)/0.08),transparent_68%)]"
+        aria-hidden="true"
+      />
       <div className="container relative z-10 mx-auto px-4">
         <div className="flex flex-col items-center gap-8 text-center">
           {/* Status Badge */}
           <div>
             <Badge
               variant="secondary"
-              className="border border-border bg-card/80 px-4 py-1.5 text-sm font-medium text-muted-foreground shadow-sm"
+              className="grounded-kicker px-4 py-1.5 text-sm font-medium text-muted-foreground"
             >
               <span className="mr-2 flex h-2 w-2">
                 <span className="absolute inline-flex h-2 w-2 animate-ping rounded-full bg-emerald-400 opacity-75"></span>
@@ -22,21 +30,19 @@ const HeroSection = () => {
           </div>
 
           {/* Main Heading */}
-          <h1 className="max-w-5xl font-sans text-5xl font-extrabold tracking-tight text-foreground sm:text-7xl">
+          <h1 className="max-w-5xl font-sans text-4xl font-extrabold leading-[1.02] tracking-tight text-foreground sm:text-6xl lg:text-7xl">
             <span className="sr-only">
               Andrew Riefenstahl — Full-Stack Engineer & AI Architect —{" "}
             </span>
             Forging the Future of <br className="hidden sm:block" />
-            <span className="bg-gradient-to-r from-[hsl(var(--hero-gradient-from))] via-[hsl(var(--hero-gradient-via))] to-[hsl(var(--hero-gradient-to))] bg-clip-text text-transparent drop-shadow-[0_6px_20px_hsl(var(--hero-gradient-to)/0.35)]">
-              Digital Intelligence
-            </span>
+            <span className="grounded-gradient-text">Digital Intelligence</span>
           </h1>
 
           {/* Subheading */}
           <p className="max-w-2xl text-lg leading-relaxed text-muted-foreground sm:text-xl">
-            I&apos;m <strong>Andrew Riefenstahl</strong>. Senior software engineer and AI
-            specialist. I build resilient systems and explore the intersection
-            of human cognition and artificial intelligence.
+            I&apos;m <strong>Andrew Riefenstahl</strong>. Senior software engineer
+            and AI specialist. I build resilient systems and explore the
+            intersection of human cognition and artificial intelligence.
           </p>
 
           {/* Actions */}
@@ -44,7 +50,7 @@ const HeroSection = () => {
             <Button
               asChild
               size="lg"
-              className="h-12 min-w-[160px] rounded-full text-base font-semibold shadow-xl transition-all hover:scale-105 hover:shadow-2xl hover:bg-primary"
+              className="grounded-button-primary h-12 min-w-[160px] rounded-full text-base font-semibold transition-all hover:-translate-y-0.5"
             >
               <a href="#projects">
                 Explore Work
@@ -55,7 +61,7 @@ const HeroSection = () => {
               asChild
               variant="outline"
               size="lg"
-              className="h-12 min-w-[160px] rounded-full border-border bg-card/60 text-base transition-all hover:bg-card hover:text-foreground"
+              className="grounded-button-outline h-12 min-w-[160px] rounded-full text-base transition-all hover:-translate-y-0.5 hover:text-foreground"
             >
               <a href="/posts/">
                 Read Insights
@@ -68,41 +74,44 @@ const HeroSection = () => {
           <h2 className="sr-only">Core focus areas</h2>
           <div className="mt-20 grid w-full max-w-5xl grid-cols-1 gap-6 sm:grid-cols-3">
             {/* Card 1: Senior Engineering */}
-            <div className="group relative overflow-hidden rounded-2xl border border-border bg-card p-8 text-left shadow-lg transition-all hover:-translate-y-2 hover:shadow-xl">
-              <div className="mb-4 inline-flex h-12 w-12 items-center justify-center rounded-xl bg-secondary text-foreground transition-colors group-hover:bg-foreground group-hover:text-background">
+            <div className="grounded-panel group rounded-lg p-8 text-left transition-all duration-300 hover:-translate-y-1">
+              <div className="grounded-icon mb-4 inline-flex h-12 w-12 items-center justify-center rounded-lg text-foreground transition-colors group-hover:bg-foreground group-hover:text-background">
                 <Code2 className="h-6 w-6" />
               </div>
-              <h3 className="mb-2 text-xl font-bold text-foreground">
+              <h3 className="relative mb-2 text-xl font-bold text-foreground">
                 Senior Engineering
               </h3>
-              <p className="text-muted-foreground">
-                Scalable architectures, automation pipelines, and robust full-stack solutions.
+              <p className="relative text-muted-foreground">
+                Scalable architectures, automation pipelines, and robust
+                full-stack solutions.
               </p>
             </div>
 
             {/* Card 2: AI & Future Tech */}
-            <div className="group relative overflow-hidden rounded-2xl border border-border bg-card p-8 text-left shadow-lg transition-all hover:-translate-y-2 hover:shadow-xl">
-              <div className="mb-4 inline-flex h-12 w-12 items-center justify-center rounded-xl bg-secondary text-foreground transition-colors group-hover:bg-foreground group-hover:text-background">
+            <div className="grounded-panel group rounded-lg p-8 text-left transition-all duration-300 hover:-translate-y-1">
+              <div className="grounded-icon mb-4 inline-flex h-12 w-12 items-center justify-center rounded-lg text-foreground transition-colors group-hover:bg-foreground group-hover:text-background">
                 <Brain className="h-6 w-6" />
               </div>
-              <h3 className="mb-2 text-xl font-bold text-foreground">
+              <h3 className="relative mb-2 text-xl font-bold text-foreground">
                 AI Innovation
               </h3>
-              <p className="text-muted-foreground">
-                Building autonomous agents, memory systems, and RAG pipelines for complex problems.
+              <p className="relative text-muted-foreground">
+                Building autonomous agents, memory systems, and RAG pipelines
+                for complex problems.
               </p>
             </div>
 
             {/* Card 3: Leadership & Ethics */}
-            <div className="group relative overflow-hidden rounded-2xl border border-border bg-card p-8 text-left shadow-lg transition-all hover:-translate-y-2 hover:shadow-xl">
-              <div className="mb-4 inline-flex h-12 w-12 items-center justify-center rounded-xl bg-secondary text-foreground transition-colors group-hover:bg-foreground group-hover:text-background">
+            <div className="grounded-panel group rounded-lg p-8 text-left transition-all duration-300 hover:-translate-y-1">
+              <div className="grounded-icon mb-4 inline-flex h-12 w-12 items-center justify-center rounded-lg text-foreground transition-colors group-hover:bg-foreground group-hover:text-background">
                 <Heart className="h-6 w-6" />
               </div>
-              <h3 className="mb-2 text-xl font-bold text-foreground">
+              <h3 className="relative mb-2 text-xl font-bold text-foreground">
                 Leadership & Ethics
               </h3>
-              <p className="text-muted-foreground">
-                Solution-oriented mentorship with a focus on sustainable, human-centric tech.
+              <p className="relative text-muted-foreground">
+                Solution-oriented mentorship with a focus on sustainable,
+                human-centric tech.
               </p>
             </div>
           </div>

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -9,10 +9,6 @@ const HeroSection = () => {
         className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-[hsl(var(--glint)/0.5)] to-transparent"
         aria-hidden="true"
       />
-      <div
-        className="pointer-events-none absolute left-1/2 top-10 h-72 w-[min(46rem,80vw)] -translate-x-1/2 rounded-full border border-[hsl(var(--glint)/0.08)] bg-[radial-gradient(circle,hsl(var(--glint)/0.08),transparent_68%)]"
-        aria-hidden="true"
-      />
       <div className="container relative z-10 mx-auto px-4">
         <div className="flex flex-col items-center gap-8 text-center">
           {/* Status Badge */}

--- a/src/components/MobileNav.tsx
+++ b/src/components/MobileNav.tsx
@@ -21,16 +21,21 @@ const MobileNav = () => {
         <Button
           variant="ghost"
           size="icon"
-          className="text-primary-foreground hover:bg-primary-foreground/10 hover:text-primary-foreground md:hidden"
+          className="rounded-full text-primary-foreground hover:bg-primary-foreground/10 hover:text-white md:hidden"
         >
           <Menu className="h-6 w-6" aria-hidden="true" />
           <span className="sr-only">Toggle navigation menu</span>
         </Button>
       </SheetTrigger>
-      <SheetContent side="right" className="w-80 border-border bg-background">
+      <SheetContent
+        side="right"
+        className="w-80 border-border bg-background shadow-[0_24px_70px_-40px_hsl(var(--depth-shadow)/1)]"
+      >
         <div className="flex h-full flex-col">
           <div className="flex items-center justify-between border-b border-border py-4">
-            <h2 className="text-lg font-semibold text-foreground">Navigation</h2>
+            <h2 className="text-lg font-semibold text-foreground">
+              Navigation
+            </h2>
           </div>
           <nav className="flex-1 py-6">
             <div className="space-y-2">
@@ -41,7 +46,7 @@ const MobileNav = () => {
                     key={item.href}
                     href={item.href}
                     onClick={handleItemClick}
-                    className="flex items-center gap-3 rounded-lg px-4 py-3 text-foreground transition-colors duration-200 hover:bg-secondary hover:text-foreground"
+                    className="flex items-center gap-3 rounded-lg border border-transparent px-4 py-3 text-foreground transition-colors duration-200 hover:border-border/70 hover:bg-secondary/75 hover:text-foreground"
                   >
                     <IconComponent className="h-5 w-5" aria-hidden="true" />
                     <span className="font-medium">{item.label}</span>

--- a/src/components/games/GameUI.tsx
+++ b/src/components/games/GameUI.tsx
@@ -86,7 +86,7 @@ export function GameUI({
 
       {/* Secret quest tracker */}
       <div
-        className={`absolute right-4 rounded-xl border px-4 py-3 shadow-lg backdrop-blur-sm ${
+        className={`absolute right-4 rounded-lg border px-4 py-3 shadow-lg ${
           showControls && !isTouchDevice ? "top-[124px]" : "top-4"
         } border-border bg-background/80 text-sm text-foreground`}
         style={{ maxWidth: 250 }}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -128,7 +128,7 @@ const structuredDataItems = [
     >
       <div class="trees-drift"></div>
       <div
-        class="absolute inset-0 bg-[radial-gradient(circle_at_50%_0%,hsl(var(--glint)/0.08),transparent_32rem),linear-gradient(180deg,transparent_0%,hsl(var(--background)/0.78)_72%)]"
+        class="absolute inset-0 bg-[radial-gradient(circle_at_50%_0%,hsl(var(--glint)/0.08),transparent_32rem),linear-gradient(180deg,transparent_0%,transparent_86%,hsl(var(--background)/0.66)_100%)]"
       >
       </div>
     </div>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -25,7 +25,10 @@ const { metaTags, structuredData } = Astro.props;
 
 const siteUrl = Astro.site ?? new URL("https://andrewriefenstahl.com");
 const canonicalUrl = new URL(metaTags.url, siteUrl).toString();
-const socialImageUrl = new URL(metaTags.image || ogImage.src, siteUrl).toString();
+const socialImageUrl = new URL(
+  metaTags.image || ogImage.src,
+  siteUrl,
+).toString();
 
 const personStructuredData = {
   "@context": "https://schema.org",
@@ -33,10 +36,7 @@ const personStructuredData = {
   name: "Andrew Riefenstahl",
   jobTitle: "Full-Stack Software Engineer & AI Architect",
   url: "https://andrewriefenstahl.com",
-  sameAs: [
-    "https://twitter.com/riefer02",
-    "https://github.com/riefer02",
-  ],
+  sameAs: ["https://twitter.com/riefer02", "https://github.com/riefer02"],
   knowsAbout: [
     "Web Development",
     "Artificial Intelligence",
@@ -115,20 +115,33 @@ const structuredDataItems = [
     }
     <Favicon />
 
-
     <!-- JSON-LD Structured Data -->
-    <script type="application/ld+json" set:html={JSON.stringify(structuredDataItems)} />
+    <script
+      type="application/ld+json"
+      set:html={JSON.stringify(structuredDataItems)}
+    />
   </head>
   <body class="bg-background text-foreground">
-    <div class="pointer-events-none fixed inset-0 z-0 overflow-hidden" aria-hidden="true">
+    <div
+      class="pointer-events-none fixed inset-0 z-0 overflow-hidden"
+      aria-hidden="true"
+    >
       <div class="trees-drift"></div>
+      <div
+        class="absolute inset-0 bg-[radial-gradient(circle_at_50%_0%,hsl(var(--glint)/0.08),transparent_32rem),linear-gradient(180deg,transparent_0%,hsl(var(--background)/0.78)_72%)]"
+      >
+      </div>
     </div>
     <Header title={metaTags.title} />
     <main>
       <slot />
     </main>
     <footer class="py-6 text-center">
-      <a href="/games/dragon-quest/" class="text-[0.5rem] leading-none text-muted-foreground/70 no-underline transition-colors hover:text-muted-foreground" aria-label="A secret">🐉</a>
+      <a
+        href="/games/dragon-quest/"
+        class="text-[0.5rem] leading-none text-muted-foreground/70 no-underline transition-colors hover:text-muted-foreground"
+        aria-label="A secret">🐉</a
+      >
     </footer>
   </body>
 </html>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -329,9 +329,9 @@
       ),
       linear-gradient(
         180deg,
-        hsl(var(--background) / 0),
-        hsl(var(--background)) 18%,
-        hsl(var(--background)) 100%
+        hsl(var(--background) / 0.08),
+        hsl(var(--background) / 0.42) 18%,
+        hsl(var(--background) / 0.52) 100%
       );
   }
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -313,7 +313,7 @@
       90deg,
       hsl(var(--foreground)) 0%,
       hsl(var(--hero-gradient-from)) 31%,
-      hsl(var(--glint)) 68%,
+      hsl(var(--hero-gradient-via)) 68%,
       hsl(var(--hero-gradient-to)) 100%
     );
     background-clip: text;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -35,8 +35,8 @@
     --surface-1: 151 22% 18%;
     --surface-2: 131 25% 29%;
     --surface-3: 119 24% 34%;
-    --glint: 151 54% 62%;
-    --glint-soft: 113 32% 68%;
+    --glint: 112 36% 60%;
+    --glint-soft: 91 28% 68%;
     --depth-shadow: 152 55% 4%;
     --hero-gradient-from: 85 22% 72%;
     --hero-gradient-via: 112 24% 48%;
@@ -80,8 +80,8 @@
     --surface-1: 151 24% 14%;
     --surface-2: 131 25% 29%;
     --surface-3: 119 26% 38%;
-    --glint: 151 58% 66%;
-    --glint-soft: 113 36% 72%;
+    --glint: 112 40% 64%;
+    --glint-soft: 91 32% 72%;
     --depth-shadow: 152 58% 3%;
     --hero-gradient-from: 85 24% 74%;
     --hero-gradient-via: 112 26% 50%;
@@ -106,7 +106,7 @@
       ),
       radial-gradient(
         circle at 85% 8%,
-        hsl(var(--glint) / 0.12),
+        hsl(var(--glint) / 0.1),
         transparent 30rem
       ),
       linear-gradient(180deg, hsl(var(--background)) 0%, hsl(153 33% 8%) 100%);
@@ -156,7 +156,7 @@
   background-repeat: repeat;
   background-size: var(--trees-tile-size) var(--trees-tile-size);
   animation: drift 120s linear infinite;
-  opacity: 0.42;
+  opacity: 0.68;
   transform: translate3d(0, 0, 0);
   contain: paint;
 }
@@ -329,9 +329,9 @@
       ),
       linear-gradient(
         180deg,
-        hsl(var(--background) / 0.08),
-        hsl(var(--background) / 0.42) 18%,
-        hsl(var(--background) / 0.52) 100%
+        hsl(var(--background) / 0.04),
+        hsl(var(--background) / 0.32) 18%,
+        hsl(var(--background) / 0.42) 100%
       );
   }
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -35,6 +35,9 @@
     --surface-1: 151 22% 18%;
     --surface-2: 131 25% 29%;
     --surface-3: 119 24% 34%;
+    --glint: 151 54% 62%;
+    --glint-soft: 113 32% 68%;
+    --depth-shadow: 152 55% 4%;
     --hero-gradient-from: 85 22% 72%;
     --hero-gradient-via: 112 24% 48%;
     --hero-gradient-to: 131 30% 36%;
@@ -77,6 +80,9 @@
     --surface-1: 151 24% 14%;
     --surface-2: 131 25% 29%;
     --surface-3: 119 26% 38%;
+    --glint: 151 58% 66%;
+    --glint-soft: 113 36% 72%;
+    --depth-shadow: 152 58% 3%;
     --hero-gradient-from: 85 24% 74%;
     --hero-gradient-via: 112 26% 50%;
     --hero-gradient-to: 131 32% 38%;
@@ -92,6 +98,18 @@
   }
   body {
     @apply bg-background text-foreground;
+    background:
+      radial-gradient(
+        circle at 15% -10%,
+        hsl(var(--primary) / 0.22),
+        transparent 28rem
+      ),
+      radial-gradient(
+        circle at 85% 8%,
+        hsl(var(--glint) / 0.12),
+        transparent 30rem
+      ),
+      linear-gradient(180deg, hsl(var(--background)) 0%, hsl(153 33% 8%) 100%);
   }
 
   /* Smooth scrolling */
@@ -119,8 +137,16 @@
 }
 
 @keyframes drift {
-  from { transform: translate3d(0, 0, 0); }
-  to { transform: translate3d(calc(var(--trees-tile-size) * -1), calc(var(--trees-tile-size) * -1), 0); }
+  from {
+    transform: translate3d(0, 0, 0);
+  }
+  to {
+    transform: translate3d(
+      calc(var(--trees-tile-size) * -1),
+      calc(var(--trees-tile-size) * -1),
+      0
+    );
+  }
 }
 
 .trees-drift {
@@ -130,6 +156,7 @@
   background-repeat: repeat;
   background-size: var(--trees-tile-size) var(--trees-tile-size);
   animation: drift 120s linear infinite;
+  opacity: 0.42;
   transform: translate3d(0, 0, 0);
   contain: paint;
 }
@@ -161,6 +188,169 @@
 }
 
 @layer components {
+  .grounded-panel {
+    position: relative;
+    overflow: hidden;
+    border: 1px solid hsl(var(--border) / 0.8);
+    background:
+      linear-gradient(145deg, hsl(var(--foreground) / 0.055), transparent 34%),
+      linear-gradient(
+        180deg,
+        hsl(var(--card) / 0.96),
+        hsl(var(--background) / 0.88)
+      );
+    box-shadow:
+      inset 0 1px 0 hsl(var(--foreground) / 0.1),
+      inset 0 -1px 0 hsl(var(--depth-shadow) / 0.72),
+      0 24px 70px -46px hsl(var(--primary) / 0.95);
+  }
+
+  .grounded-panel::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background:
+      linear-gradient(120deg, hsl(var(--glint) / 0.16), transparent 28%),
+      radial-gradient(
+        circle at 100% 0%,
+        hsl(var(--glint-soft) / 0.13),
+        transparent 18rem
+      );
+    opacity: 0.62;
+    transition: opacity 240ms ease;
+  }
+
+  .grounded-panel::after {
+    content: "";
+    position: absolute;
+    inset: 1px;
+    pointer-events: none;
+    border-radius: inherit;
+    box-shadow: inset 0 0 0 1px hsl(var(--foreground) / 0.035);
+  }
+
+  .grounded-panel:hover {
+    border-color: hsl(var(--glint) / 0.56);
+    box-shadow:
+      inset 0 1px 0 hsl(var(--foreground) / 0.13),
+      inset 0 -1px 0 hsl(var(--depth-shadow) / 0.75),
+      0 34px 90px -48px hsl(var(--glint) / 0.86);
+  }
+
+  .grounded-panel:hover::before {
+    opacity: 0.92;
+  }
+
+  .grounded-icon {
+    border: 1px solid hsl(var(--foreground) / 0.09);
+    background:
+      linear-gradient(145deg, hsl(var(--foreground) / 0.1), transparent),
+      hsl(var(--secondary) / 0.78);
+    box-shadow:
+      inset 0 1px 0 hsl(var(--foreground) / 0.11),
+      0 16px 32px -24px hsl(var(--glint) / 0.75);
+  }
+
+  .grounded-kicker {
+    border: 1px solid hsl(var(--glint) / 0.35);
+    background:
+      linear-gradient(
+        180deg,
+        hsl(var(--foreground) / 0.07),
+        hsl(var(--card) / 0.82)
+      ),
+      hsl(var(--background));
+    box-shadow:
+      inset 0 1px 0 hsl(var(--foreground) / 0.12),
+      0 18px 42px -32px hsl(var(--glint) / 0.8);
+  }
+
+  .grounded-button-primary {
+    border: 1px solid hsl(var(--glint) / 0.28);
+    background:
+      linear-gradient(180deg, hsl(var(--primary) / 1), hsl(122 25% 28%)),
+      hsl(var(--primary));
+    box-shadow:
+      inset 0 1px 0 hsl(var(--foreground) / 0.16),
+      0 18px 42px -25px hsl(var(--glint) / 0.8);
+  }
+
+  .grounded-button-primary:hover {
+    background:
+      linear-gradient(180deg, hsl(119 28% 42%), hsl(122 27% 31%)),
+      hsl(var(--primary));
+    box-shadow:
+      inset 0 1px 0 hsl(var(--foreground) / 0.2),
+      0 24px 56px -28px hsl(var(--glint) / 0.92);
+  }
+
+  .grounded-button-outline {
+    border: 1px solid hsl(var(--foreground) / 0.13);
+    background:
+      linear-gradient(
+        180deg,
+        hsl(var(--foreground) / 0.055),
+        hsl(var(--card) / 0.48)
+      ),
+      hsl(var(--background));
+    box-shadow: inset 0 1px 0 hsl(var(--foreground) / 0.08);
+  }
+
+  .grounded-button-outline:hover {
+    border-color: hsl(var(--glint) / 0.44);
+    background:
+      linear-gradient(
+        180deg,
+        hsl(var(--foreground) / 0.08),
+        hsl(var(--secondary) / 0.68)
+      ),
+      hsl(var(--background));
+  }
+
+  .grounded-gradient-text {
+    background-image: linear-gradient(
+      90deg,
+      hsl(var(--foreground)) 0%,
+      hsl(var(--hero-gradient-from)) 31%,
+      hsl(var(--glint)) 68%,
+      hsl(var(--hero-gradient-to)) 100%
+    );
+    background-clip: text;
+    color: transparent;
+  }
+
+  .grounded-section {
+    background:
+      radial-gradient(
+        circle at 50% 0%,
+        hsl(var(--glint) / 0.07),
+        transparent 34rem
+      ),
+      linear-gradient(
+        180deg,
+        hsl(var(--background) / 0),
+        hsl(var(--background)) 18%,
+        hsl(var(--background)) 100%
+      );
+  }
+
+  .grounded-section-heading {
+    text-wrap: balance;
+  }
+
+  .grounded-chip {
+    border: 1px solid hsl(var(--border) / 0.76);
+    background:
+      linear-gradient(
+        180deg,
+        hsl(var(--foreground) / 0.055),
+        hsl(var(--secondary) / 0.55)
+      ),
+      hsl(var(--background));
+    box-shadow: inset 0 1px 0 hsl(var(--foreground) / 0.07);
+  }
+
   .article-prose :is(h2, h3, h4) {
     scroll-margin-top: 7rem;
   }


### PR DESCRIPTION
## What changed

- Refined the portfolio surface system with stronger borders, layered gradients, sharper shadows, and cleaner hover states.
- Kept the centered homepage structure and restored the original visible copy.
- Removed homepage/shared reliance on blur/backdrop-filter effects and replaced the game quest tracker backdrop blur with an opaque surface.
- Updated Browserslist data and changed the web manifest start URL to `/` so local and preview origins do not emit manifest warnings.

## Why

The site already had a good voice and layout. This pass focuses on the UI finish: more depth and polish from browser-stable CSS primitives instead of blur-heavy effects that can flicker in Chrome.

## Validation

- `pnpm build`
- Chrome desktop screenshot check
- Chrome mobile viewport check at 390x844
- Verified mobile has no horizontal overflow
- Verified console has no warnings/errors after the manifest fix